### PR TITLE
Fix: the location service doesn't starts

### DIFF
--- a/location_service/lib/example_page_controller.dart
+++ b/location_service/lib/example_page_controller.dart
@@ -52,7 +52,7 @@ class ExamplePageController {
         playSound: false,
       ),
       foregroundTaskOptions: ForegroundTaskOptions(
-        eventAction: ForegroundTaskEventAction.nothing(),
+        eventAction: ForegroundTaskEventAction.once(),
         autoRunOnBoot: true,
         autoRunOnMyPackageReplaced: true,
         allowWakeLock: true,


### PR DESCRIPTION
With .nothing() nothing happens: just the notification is being shown, but the location service is not being initialized.

I tried changing it to .once() and the it started to stream correctly the location.